### PR TITLE
Always recycle TypedArray.

### DIFF
--- a/colorpickerpreference/src/main/java/com/skydoves/colorpickerpreference/ColorPickerPreference.kt
+++ b/colorpickerpreference/src/main/java/com/skydoves/colorpickerpreference/ColorPickerPreference.kt
@@ -74,13 +74,21 @@ class ColorPickerPreference : Preference {
 
   private fun getAttrs(attrs: AttributeSet) {
     val typedArray = context.obtainStyledAttributes(attrs, R.styleable.ColorPickerPreference)
-    setTypeArray(typedArray)
+    try {
+      setTypeArray(typedArray)
+    } finally {
+      typedArray.recycle()
+    }
   }
 
   private fun getAttrs(attrs: AttributeSet, defStyle: Int) {
     val typedArray =
       context.obtainStyledAttributes(attrs, R.styleable.ColorPickerPreference, defStyle, 0)
-    setTypeArray(typedArray)
+    try {
+      setTypeArray(typedArray)
+    } finally {
+      typedArray.recycle()
+    }
   }
 
   private fun setTypeArray(typedArray: TypedArray) {


### PR DESCRIPTION
- This makes sure the `TypedArray` is recycled whatever happens when it is used.
  - See: https://developer.android.com/reference/android/content/res/TypedArray.
- This is kind of a bugfix.
- This is a non-breaking change.