### PR TITLE
support building preference in code

### DIFF
--- a/colorpickerpreference/src/main/java/com/skydoves/colorpickerpreference/ColorPickerPreference.kt
+++ b/colorpickerpreference/src/main/java/com/skydoves/colorpickerpreference/ColorPickerPreference.kt
@@ -114,7 +114,7 @@ class ColorPickerPreference : Preference {
       )
   }
 
-  private fun onInit() {
+  fun onInit() {
     widgetLayoutResource = R.layout.layout_colorpicker_preference
     preferenceDialog = ColorPickerDialog.Builder(context).apply {
       setTitle(dialogTitle)

--- a/colorpickerpreference/src/main/java/com/skydoves/colorpickerpreference/ColorPickerPreference.kt
+++ b/colorpickerpreference/src/main/java/com/skydoves/colorpickerpreference/ColorPickerPreference.kt
@@ -51,11 +51,11 @@ class ColorPickerPreference : Preference {
   var cornerRadius: Int = 0
   var paletteDrawable: Drawable? = null
   var selectorDrawable: Drawable? = null
-  var title: String? = null
+  var dialogTitle: String? = null
   var positive: String? = null
   var negative: String? = null
-  var isAttachAlphaSlideBar = true
-  var isAttachBrightnessSlideBar = true
+  var attachAlphaSlideBar = true
+  var attachBrightnessSlideBar = true
 
   constructor(context: Context) : super(context)
 
@@ -99,25 +99,25 @@ class ColorPickerPreference : Preference {
       typedArray.getDimensionPixelSize(R.styleable.ColorPickerPreference_preference_colorBox_radius, cornerRadius)
     paletteDrawable = typedArray.getDrawable(R.styleable.ColorPickerPreference_preference_palette)
     selectorDrawable = typedArray.getDrawable(R.styleable.ColorPickerPreference_preference_selector)
-    title = typedArray.getString(R.styleable.ColorPickerPreference_preference_dialog_title)
+    dialogTitle = typedArray.getString(R.styleable.ColorPickerPreference_preference_dialog_title)
     positive = typedArray.getString(R.styleable.ColorPickerPreference_preference_dialog_positive)
     negative = typedArray.getString(R.styleable.ColorPickerPreference_preference_dialog_negative)
-    isAttachAlphaSlideBar =
+    attachAlphaSlideBar =
       typedArray.getBoolean(
         R.styleable.ColorPickerPreference_preference_attachAlphaSlideBar,
-        isAttachAlphaSlideBar
+        attachAlphaSlideBar
       )
-    isAttachBrightnessSlideBar =
+    attachBrightnessSlideBar =
       typedArray.getBoolean(
         R.styleable.ColorPickerPreference_preference_attachBrightnessSlideBar,
-        isAttachBrightnessSlideBar
+        attachBrightnessSlideBar
       )
   }
 
   private fun onInit() {
     widgetLayoutResource = R.layout.layout_colorpicker_preference
     preferenceDialog = ColorPickerDialog.Builder(context).apply {
-      setTitle(title)
+      setTitle(dialogTitle)
       setPositiveButton(
         positive,
         ColorEnvelopeListener { envelope, _ ->
@@ -132,8 +132,8 @@ class ColorPickerPreference : Preference {
         }
       )
       setNegativeButton(negative) { dialogInterface, _ -> dialogInterface.dismiss() }
-      attachAlphaSlideBar(isAttachAlphaSlideBar)
-      attachBrightnessSlideBar(isAttachBrightnessSlideBar)
+      attachAlphaSlideBar(attachAlphaSlideBar)
+      attachBrightnessSlideBar(attachBrightnessSlideBar)
       this@ColorPickerPreference.preferenceColorPickerView = this.colorPickerView.apply {
         paletteDrawable?.let { setPaletteDrawable(it) }
         selectorDrawable?.let { setSelectorDrawable(it) }

--- a/colorpickerpreference/src/main/java/com/skydoves/colorpickerpreference/ColorPickerPreference.kt
+++ b/colorpickerpreference/src/main/java/com/skydoves/colorpickerpreference/ColorPickerPreference.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:Suppress("unused")
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
 
 package com.skydoves.colorpickerpreference
 
@@ -47,15 +47,15 @@ class ColorPickerPreference : Preference {
   private lateinit var preferenceColorPickerView: ColorPickerView
   var preferenceColorListener: ColorPickerViewListener? = null
 
-  private var defaultColor: Int = Color.BLACK
-  private var cornerRadius: Int = 0
-  private var paletteDrawable: Drawable? = null
-  private var selectorDrawable: Drawable? = null
-  private var title: String? = null
-  private var positive: String? = null
-  private var negative: String? = null
-  private var isAttachAlphaSlideBar = true
-  private var isAttachBrightnessSlideBar = true
+  var defaultColor: Int = Color.BLACK
+  var cornerRadius: Int = 0
+  var paletteDrawable: Drawable? = null
+  var selectorDrawable: Drawable? = null
+  var title: String? = null
+  var positive: String? = null
+  var negative: String? = null
+  var isAttachAlphaSlideBar = true
+  var isAttachBrightnessSlideBar = true
 
   constructor(context: Context) : super(context)
 


### PR DESCRIPTION
This PR allows the preference configuration to be set in code, allowing this library to be used when [programmatically building a preference screen](https://developer.android.com/guide/topics/ui/settings/programmatic-hierarchy). For example:

```kotlin
override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
	val context = preferenceManager.context
	val screen = preferenceManager.createPreferenceScreen(context)

	val colorPref = ColorPickerPreference(context).apply {
		key = getString(R.string.bgColorKey)
		title = "Background Color"
		defaultColor = R.color.black
		attachAlphaSlideBar = false
		positive = "Confirm"
		negative = "Cancel"
		onInit()
		getColorPickerView().flagView = BubbleFlag(context)
	}
	screen.addPreference(colorPref)

	preferenceScreen = screen
}
```



### Types of changes
What types of changes does your code introduce?

- [x] New feature (non-breaking change which adds functionality)

The only changes needed were making a couple fields/methods public.
